### PR TITLE
Added the code for missing SKU in current month w.r.t the previous month

### DIFF
--- a/dags/Amazon_Web_Scraping/SQL/AMZ_MS_Data_backup.sql
+++ b/dags/Amazon_Web_Scraping/SQL/AMZ_MS_Data_backup.sql
@@ -1,3 +1,14 @@
+-- Before starting with the new data append first add the missing SKU from the Amazon coming data to the same table w.r.t previous month data 
+
+INSERT INTO `shopify-pubsub-project.Amazon_Market_Sizing.AMZ_Market_Sizing`
+select 
+ CM.* 
+from `shopify-pubsub-project.Amazon_Market_Sizing.AMZ_current_month_MS` as CM
+left join `shopify-pubsub-project.Amazon_Market_Sizing.AMZ_Market_Sizing` as ND 
+on CM.Child_ASIN = ND.Child_ASIN
+where ND.Child_ASIN is null;
+
+
 -- drop the current table
 DROP TABLE `shopify-pubsub-project.Amazon_Market_Sizing.AMZ_current_month_MS`;
 


### PR DESCRIPTION
Before dropping the amazon table which is created from the python code first we are checking the missing SKU with current_month table which has the previous month data and append it in Amazon_scraping table once done then proceed with the merging,cleaning and deleting of the table