### PR TITLE
Update dataset ID for Google Play Ratings API

### DIFF
--- a/dags/reviews/play_store/get_playstore_reviews.py
+++ b/dags/reviews/play_store/get_playstore_reviews.py
@@ -18,7 +18,7 @@ import json
 class GooglePlayRatingsAPI:
     def __init__(self):
         self.project_id = "shopify-pubsub-project"
-        self.dataset_id = "reviews"
+        self.dataset_id = "pilgrim_bi_google_play"
         self.table_id = f'{self.project_id}.{self.dataset_id}.{GooglePlayRatings.__tablename__}'
 
         # BigQuery connection string


### PR DESCRIPTION
Change the dataset ID used in the Google Play Ratings API to reflect the new naming convention.