### PR TITLE
Add mail subject handling to ExtractReportData

### DIFF
--- a/dags/nykaa/tasks.py
+++ b/dags/nykaa/tasks.py
@@ -61,8 +61,11 @@ def nykaa_email_report_sheet():
             attachment_data = attachments_client.get(userId="me", messageId=mail["id"], id=mail_attachment['body']['attachmentId']).execute()
             attachment_bytes = BytesIO(base64.urlsafe_b64decode(attachment_data['data'] + '=' * (4 - len(attachment_data['data']) % 4)))
             mail_date = datetime.fromtimestamp(int(email_data['internalDate'])//1000)
-            
-            extractor = ExtractReportData(attachment_bytes)
+            email_headers = email_data['payload']['headers']
+            mail_subject = [header['value'] for header in email_headers if header['name'] == 'Subject']
+            mail_subject = mail_subject[0] if mail_subject else None
+
+            extractor = ExtractReportData(attachment_bytes, mail_subject)
             extractor.sync(mail_date, int(datetime.now().strftime("%Y%m%d%H%M%S")), SCHEMA)
             messages_client.modify(userId="me", id=mail["id"], body=dict(removeLabelIds=["UNREAD"])).execute()
     


### PR DESCRIPTION
This pull request includes changes to the `dags/nykaa` module to enhance the email processing functionality by adding support for email subjects. The main updates involve modifying the `ExtractReportData` class and its methods to handle the email subject and include it in the data loaded to BigQuery.

Enhancements to email processing:

* [`dags/nykaa/parser.py`](diffhunk://#diff-7ea1a77dd6b825e5c1719e6ee72366c2348dbb2769cffb407413347532281576L13-R21): Updated the `ExtractReportData` class constructor to accept `mail_subject` and store it as an instance variable.
* [`dags/nykaa/parser.py`](diffhunk://#diff-7ea1a77dd6b825e5c1719e6ee72366c2348dbb2769cffb407413347532281576L94-R100): Modified the `load_data_to_bigquery` method to include `mail_subject` and `pg_mail_recieved_at` in the data being loaded to BigQuery.
* [`dags/nykaa/parser.py`](diffhunk://#diff-7ea1a77dd6b825e5c1719e6ee72366c2348dbb2769cffb407413347532281576L112-R115): Adjusted the retry logic in `load_data_to_bigquery` to pass `mail_recieved_at` correctly during retries.
* [`dags/nykaa/tasks.py`](diffhunk://#diff-e31d773299d2d3a6cd7d7078e68e77db564b61c9f38525f13d31975d58119ebcR64-R68): Extracted the email subject from the email headers and passed it to the `ExtractReportData` constructor.